### PR TITLE
feature: Support `sudo` & SSH connection options

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,9 +198,16 @@ lollypops.deployment = {
   # Where on the remote the configuration (system flake) is placed
   config-dir = "/var/src/lollypops";
 
-  # Ssh connection parameters
-  host = "${config.networking.hostName}";
-  user = "root";
+  # SSH connection parameters
+  ssh.host = "${config.networking.hostName}";
+  ssh.user = "root";
+  ssh.command = "ssh";
+  ssh.opts = [];
+
+  # sudo options
+  sudo.enable = false;
+  sudo.command = "sudo";
+  sudo.opts = [];
 };
 ```
 
@@ -213,6 +220,9 @@ the lollypops module will add the package to `environment.systemPackages` it may
 be missing still on the first deployment. To fix this, either add it to your
 $PATH on the remote side or do your first deployment with
 `lollypops.deployment.local-evaluation` set to `true`.
+
+**Note:** If your flake includes remote Git repositories in its inputs, `git` is
+required to be installed on the remote host.
 
 ### Secrets
 

--- a/module.nix
+++ b/module.nix
@@ -95,22 +95,59 @@ in
         description = "Path to place the configuration on the remote host";
       };
 
-      host = mkOption {
-        type = types.str;
-        default = "${config.networking.hostName}";
-        description = "Host to deploy to";
-        defaultText = "<config.networking.hostName>";
+      sudo = {
+
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Enables the use of sudo for deployment on remote servers";
+        };
+
+        command = mkOption {
+          type = types.str;
+          default = "sudo";
+          description = "Command to run for permission elevation";
+        };
+
+        opts = mkOption {
+          type = types.listOf types.str;
+          default = [ "" ];
+          example = [ "--user=user" ];
+          description = "Options to pass to the configured sudo command";
+        };
       };
 
-      user = mkOption {
-        type = types.str;
-        default = "root";
-        description = "User to deploy as";
+      ssh = {
+
+        command = mkOption {
+          type = types.str;
+          default = "ssh";
+          description = "Command to run for connection to another server";
+        };
+
+        opts = mkOption {
+          type = types.listOf types.str;
+          default = [ "" ];
+          example = [ "-A" ];
+          description = "Options to pass to the configured SSH command";
+        };
+
+        host = mkOption {
+          type = types.str;
+          default = "${config.networking.hostName}";
+          description = "Host to deploy to";
+        };
+
+        user = mkOption {
+          type = types.str;
+          default = "root";
+          description = "User to deploy as";
+        };
       };
     };
   };
 
   config = {
-     environment.systemPackages = with pkgs; [ rsync ];
+    environment.systemPackages = with pkgs; [ rsync ];
   };
 }


### PR DESCRIPTION
These changes (based on @arouzing's initial work, thank you!) introduce
configuration options for SSH connections and add support for using sudo.

Tested thoroughly on several systems and works as expected :)  
I also fixed a bug on initial deploys by adding the `--mkpath` arg to rsync, otherwise systems fail to deploy on initial attempt.