### PR TITLE
Add ability to set ssh and sudo options with environment variables

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,12 +75,12 @@
                       ];
 
                       vars = with hostConfig.config.lollypops; {
-                        REMOTE_USER = ''{{default "${deployment.ssh.user}" .REMOTE_USER}}'';
-                        REMOTE_HOST = ''{{default "${deployment.ssh.host}" .REMOTE_HOST}}'';
-                        REMOTE_COMMAND = ''{{default "${deployment.ssh.command}" .REMOTE_COMMAND}}'';
-                        REMOTE_SSH_OPTS = ''{{default "${pkgs.lib.concatStrings deployment.ssh.opts}" .REMOTE_SSH_OPTS}}'';
-                        REMOTE_SUDO_COMMAND = ''{{default "${deployment.sudo.command}" .REMOTE_SUDO_COMMAND}}'';
-                        REMOTE_SUDO_OPTS = ''{{default "${pkgs.lib.concatStrings deployment.sudo.opts}" .REMOTE_SUDO_OPTS}}'';
+                        REMOTE_USER = ''{{default "${deployment.ssh.user}" .LP_REMOTE_USER}}'';
+                        REMOTE_HOST = ''{{default "${deployment.ssh.host}" .LP_REMOTE_HOST}}'';
+                        REMOTE_COMMAND = ''{{default "${deployment.ssh.command}" .LP_REMOTE_COMMAND}}'';
+                        REMOTE_SSH_OPTS = ''{{default "${pkgs.lib.concatStrings deployment.ssh.opts}" .LP_REMOTE_SSH_OPTS}}'';
+                        REMOTE_SUDO_COMMAND = ''{{default "${deployment.sudo.command}" .LP_REMOTE_SUDO_COMMAND}}'';
+                        REMOTE_SUDO_OPTS = ''{{default "${pkgs.lib.concatStrings deployment.sudo.opts}" .LP_REMOTE_SUDO_OPTS}}'';
                         REBUILD_ACTION = ''{{default "switch" .REBUILD_ACTION}}'';
                         REMOTE_CONFIG_DIR = deployment.config-dir;
                         LOCAL_FLAKE_SOURCE = configFlake;


### PR DESCRIPTION
For me, it isn't always convenient to set ssh options in the nixos configuration. I use different hosts to deploy from and they have different network setups, so target host has different addresses. I could use `~/.ssh/config` but imo it is more convenient to use environment variables.
This commit adds ability to set REMOTE_HOST, REMOTE_USER and other options with environment variables.