### PR TITLE
feature: configurable/extensible tasks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -200,7 +200,7 @@
                               ''
                             ];
                           };
-                        };
+                        } // hostConfig.config.lollypops.extraTasks;
                     });
 
                   # Taskfile passed to go-task
@@ -230,12 +230,7 @@
                         (name: value:
                           {
                             desc = "Provision host: ${name}";
-                            cmds = [
-                              # TODO make these configurable, set these three as default in the module
-                              { task = "${name}:deploy-flake"; }
-                              { task = "${name}:deploy-secrets"; }
-                              { task = "${name}:rebuild"; }
-                            ];
+                            cmds = map (task: { task = "${name}:${task}"; }) value.config.lollypops.tasks;
                           })
                         configFlake.nixosConfigurations // {
                         # Add special task called "all" which has all hosts as

--- a/module.nix
+++ b/module.nix
@@ -145,6 +145,44 @@ in
         };
       };
     };
+
+    tasks = mkOption {
+      type = types.listOf types.str;
+      default = [ "deploy-flake" "deploy-secrets" "rebuild" ];
+      description = "The list of tasks to run for each host.";
+    };
+
+    extraTasks = mkOption {
+      type = types.attrsOf (types.submodule {
+        options = {
+          dir = mkOption {
+            type = types.either types.path types.str;
+            default = ".";
+            description = "Directory in which the task should run.";
+          };
+          deps = mkOption {
+            type = types.listOf types.str;
+            default = [ ];
+            description = "Dependencies for the task.";
+          };
+          desc = mkOption {
+            type = types.str;
+            description = "Description for the task.";
+          };
+          cmds = mkOption {
+            type = types.listOf types.str;
+            description = "Commands for the task.";
+          };
+        };
+      });
+      default = { };
+      description = ''
+        Extra tasks to run for the host. If any are defined with the same name as the default tasks
+        (<literal>deploy-secrets</literal>, <literal>rebuild</literal>, <literal>deploy-flake</literal>)
+        the original tasks will be overriden.
+      '';
+
+    };
   };
 
   config = {


### PR DESCRIPTION
Hey again @pinpox 👋 Hope you've been well :)

These changes introduce the `lollypops.tasks` & `lollypops.extraTasks` options to the module. See the associated change to the README to get an idea of its use case.

Here's an example of how I'm using it in one such case: macOS with Nix set up, config for all systems kept in my flake. One of my systems is a Raspberry Pi 4B, not all that powerful for building its own system closure. So, using lollypops in my flake, for the host definition of that system I:
- ensure an aarch64 build VM is running on the MacBook (near native perf with [Tart](https://tart.run/))
- (this VM is set up in Nix as a remote builder for aarch64-linux systems)
- instead of running a `nixos-rebuild` on the Pi remotely, I defer to ruinning `nix build` locally, which offloads the build tasks to the VM, since it's for an aarch64-linux system
- copy the built closure to the Pi, then instruct it to switch the system profile to this

<details><summary>Details</summary>
<p>

```nix
{
  nixosConfigurations.net1 = nixpkgs.lib.nixosSystem {
    system = "aarch64-linux";
    modules = commonLinuxConfig ++ [
      ./bases/net1.nix
      ./bases/server.nix

      {
        lollypops.deployment.local-evaluation = true;
        lollypops.secrets = {
          files = {
            "net1/wireguard-privatekey" = { };
            "net1/acme-dnsimple-envfile" = { };
          };
        };

        # Use `nix-build` to rely on build1 VM
        lollypops.tasks = [ "deploy-secrets" "rebuild" ];
        lollypops.extraTasks = {
          bootstrap-builder = {
            deps = [ "check-vars" ];
            desc = "Ensure the build VM is running";
            cmds = [
              ''
                { tart list --format json | jq -e '.[]|select(.Name=="build1")|any' > /dev/null; } || \
                { echo "No VM called 'build1' found..." ; exit 1; }
              ''
              ''
                if tart list --format json \
                   | jq -e '.[]|select(.Name=="build1" and .Running==true)|any' \
                   > /dev/null; then
                  echo "build1 is up...";
                else
                  echo "booting build1..."
                  nohup tart run --no-graphics --net-bridged=en0 --rosetta="rosetta" build1 >/dev/null 2>&1 &

                  count=0
                  max_tries=15

                  echo "Waiting for build1 to come up..."

                  while [ $count -lt $max_tries ]; do
                    if nc -vz build1 22 > /dev/null 2>&1; then
                      echo "Looks like build1 is ready!"
                      exit 0
                    fi

                    count=$((count + 1))
                    sleep 1
                  done

                  echo "Failed after $max_tries attempts."
                  exit 1
                fi
              ''
            ];
          };
          rebuild = {
            dir = ".";
            deps = [ "bootstrap-builder" ];
            desc = "Rebuild configuration of: net1";
            cmds = [
              ''
                nix build -L \
                ${self}#nixosConfigurations.net1.config.system.build.toplevel && \
                REAL_PATH=$(realpath ./result) && \
                nix copy -s --to ssh://admin@net1 $REAL_PATH 2>&1 && \
                ssh admin@net1 \
                "sudo nix-env -p /nix/var/nix/profiles/system --set $REAL_PATH && \
                sudo /nix/var/nix/profiles/system/bin/switch-to-configuration switch"
              ''
            ];
          };
        };
      }
    ];
  };
}
```

</p>
</details> 

These added features have proven really useful for doing something like this, rather than having to figure out awkward ways of implementing it as nuanced feature with a bunch of conditionals.

I'm not tied to any implementation details, namings or descriptions. So please do feel free to suggest any changes you'd like to see :) I've done thorough testing and it all seems to work nicely