### PR TITLE
assertion: cfg.deployment.local-evaluation -> !cfg.deployment.sudo.enable

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -186,6 +186,13 @@ in
   };
 
   config = {
+    assertions = [
+      {
+        assertion = cfg.deployment.local-evaluation -> !cfg.deployment.sudo.enable;
+        message = "You cannot combine `lollypops.deployment.local-evaluation` " +
+          "with `lollypops.deployment.sudo.enable`.";
+      }
+    ];
     environment.systemPackages = with pkgs; [ rsync ];
   };
 }


### PR DESCRIPTION
As discussed before, it is not possible to combine local-evolution with using sudo.
local-evolution: we copy the closure into a remote nix-store. This requires the root user.

This assertion might be helpful for people wondering why something does not work...