### PR TITLE
Set secrets directory permissions to 701

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
 
                       # Create parent directory if it does not exist
                       ''
-                        ssh {{.REMOTE_USER}}@{{.REMOTE_HOST}} 'umask 077; sudo -u ${user} mkdir -p "$(dirname ${pkgs.lib.escapeShellArg secretConfig.path})"'
+                        ssh {{.REMOTE_USER}}@{{.REMOTE_HOST}} 'umask 076; sudo -u ${user} mkdir -p "$(dirname ${pkgs.lib.escapeShellArg secretConfig.path})"'
                       ''
                       # Copy file
                       ''
@@ -111,7 +111,7 @@
                                     # Create parent directory if it does not exist
                                     ''
                                       {{.REMOTE_COMMAND}} {{.REMOTE_OPTS}} {{.REMOTE_USER}}@{{.REMOTE_HOST}} \
-                                      '${optionalString useSudo "{{.REMOTE_SUDO_COMMAND}} {{.REMOTE_SUDO_OPTS}} "} install -d -m 700 "$(dirname ${path})"'
+                                      'umask 076; ${optionalString useSudo "{{.REMOTE_SUDO_COMMAND}} {{.REMOTE_SUDO_OPTS}} "} mkdir -p "$(dirname ${path})"'
                                     ''
 
                                     # Copy file


### PR DESCRIPTION
This PR ensures users that own secrets can read them if they are not the remote SSH user.

- I would suggest replacing 700 permissions by 701 permissions. Execute permissions are necessary and sufficient for the user to access secrets they own. Adding a keys group makes things more complicated with little benefit, since 710 permissions will still be necessary.
- I do not use the home-manager module, but I assume the same problem arises here, since you use umask 077. Changing that to umask 076 when creating the parent directory should do the trick.
- Note that the install command actually creates any non-existing parent directories with 755 permissions, not with the permissions set by the -m option. This might not be what you actually want and I would recommend changing to to a umask and mkdir like you did before.