### PR TITLE
Add group name option to hosts, and a task to deploy each group

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -95,6 +95,12 @@ in
         description = "Path to place the configuration on the remote host";
       };
 
+      group = mkOption {
+        type = types.str;
+        default = "default";
+        description = "Group name for the host, used to perform actions against a group of servers";
+      };
+
       sudo = {
 
         enable = mkOption {


### PR DESCRIPTION
This is for #26 

I added a new option to specify a group name for each host like this:

``` nix
lollypops.deployment = {
            ssh.host = "1.2.3.4";
            ssh.user = "root";
            group = "nomad-server";
          };
```

And now when the module generates the Taskfile, it creates a new helper task for each unique group name.   For example, this is with a few servers that have the group names "nomad-server" and "nomad-client":

```
> nix run '.' -- --list-all
...
task: Available tasks for this project:
* all:
* nixnomadclient1-01:                       Provision host: nixnomadclient1-01
* nixnomadclient1-02:                       Provision host: nixnomadclient1-02
* nixnomadsrv1-01:                          Provision host: nixnomadsrv1-01
* nixnomadsrv1-02:                          Provision host: nixnomadsrv1-02
* nixnomadsrv1-03:                          Provision host: nixnomadsrv1-03
* nomad-client:                             Provision group: nomad-client
* nomad-server:                             Provision group: nomad-server
* nixnomadclient1-01:check-vars:
```

This seems to work and satisfies what I wanted in #26 since I couldn't figure out a clean way to do it without modifying the lollypops module.

I am not sure about the task name though.   Right now it's just the same as the group name, but I wonder if it'd be better to prefix it with `group:` or `all:`? 