### PR TITLE
Deploy using `nix flake archive` or `nix copy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,14 +217,8 @@ Setting `lollypops.deployment.local-evaluation` to true, will result in
 evaluation being done on the local side. This requires `nixos-rebuild` in your
 `$PATH`
 
-**Note:** Rsync is required on the remote for remote evaluation to work. While
-the lollypops module will add the package to `environment.systemPackages` it may
-be missing still on the first deployment. To fix this, either add it to your
-$PATH on the remote side or do your first deployment with
-`lollypops.deployment.local-evaluation` set to `true`.
-
-**Note:** If your flake includes remote Git repositories in its inputs, `git` is
-required to be installed on the remote host.
+**Note:** If using `sudo`, the user you're connecting as still needs to be able
+to access the Nix daemon. This is the default in NixOS.
 
 ### Secrets
 

--- a/README.md
+++ b/README.md
@@ -197,9 +197,6 @@ a lot of cases.
 
 ```nix
 lollypops.deployment = {
-  # Where on the remote the configuration (system flake) is placed
-  config-dir = "/var/src/lollypops";
-
   # SSH connection parameters
   ssh.host = "${config.networking.hostName}";
   ssh.user = "root";

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1700390070,
-        "narHash": "sha256-de9KYi8rSJpqvBfNwscWdalIJXPo8NjdIZcEJum1mH0=",
+        "lastModified": 1712439257,
+        "narHash": "sha256-aSpiNepFOMk9932HOax0XwNxbA38GOUVOiXfUVPOrck=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e4ad989506ec7d71f7302cc3067abd82730a4beb",
+        "rev": "ff0dbd94265ac470dda06a657d5fe49de93b4599",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -187,8 +187,8 @@
                                     ${optionalString useSudo "--use-remote-sudo"}
                                 '' else ''
                                 {{.REMOTE_COMMAND}} {{.REMOTE_SSH_OPTS}} {{.REMOTE_USER}}@{{.REMOTE_HOST}} \
-                                  "${optionalString useSudo "{{.REMOTE_SUDO_COMMAND}} {{.REMOTE_SUDO_OPTS}}"} nixos-rebuild {{.REBUILD_ACTION}} \
-                                  --flake "$(readlink -f {{.REMOTE_CONFIG_DIR}}/flake)#{{.HOSTNAME}}""
+                                  '${optionalString useSudo "{{.REMOTE_SUDO_COMMAND}} {{.REMOTE_SUDO_OPTS}}"} nixos-rebuild {{.REBUILD_ACTION}} \
+                                  --flake "$(readlink -f {{.REMOTE_CONFIG_DIR}}/flake)#{{.HOSTNAME}}"'
                               '')
                             ];
                           };

--- a/flake.nix
+++ b/flake.nix
@@ -199,12 +199,22 @@
                             desc = "Deploy flake repository to: ${hostName}";
                             cmds = [
                               ''echo "Deploying flake to: {{.HOSTNAME}}"''
-                              ''
-                                NIX_SSHOPTS="{{.REMOTE_SSH_OPTS}}" nix flake archive \
-                                  --to ssh://{{.REMOTE_USER}}@{{.REMOTE_HOST}} \
-                                  --option builders-use-substitutes true \
-                                  {{.LOCAL_FLAKE_SOURCE}}
-                              ''
+                              (if  hostConfig.config.lollypops.deployment.deploy-method == "archive" then
+                                ''
+                                  NIX_SSHOPTS="{{.REMOTE_SSH_OPTS}}" nix flake archive \
+                                    --to ssh://{{.REMOTE_USER}}@{{.REMOTE_HOST}} \
+                                    --option builders-use-substitutes true \
+                                    {{.LOCAL_FLAKE_SOURCE}}
+                                ''
+                              else
+                                ''
+                                  NIX_SSHOPTS="{{.REMOTE_SSH_OPTS}}" nix copy \
+                                    --to ssh://{{.REMOTE_USER}}@{{.REMOTE_HOST}} \
+                                    --substitute-on-destination \
+                                    --option builders-use-substitutes true \
+                                    {{.LOCAL_FLAKE_SOURCE}}
+                                ''
+                              )
                               ''
                                 {{.REMOTE_COMMAND}} {{.REMOTE_SSH_OPTS}} {{.REMOTE_USER}}@{{.REMOTE_HOST}} \
                                   "${optionalString useSudo "{{.REMOTE_SUDO_COMMAND}} {{.REMOTE_SUDO_OPTS}}"} ln -sfn {{.LOCAL_FLAKE_SOURCE}} {{.REMOTE_CONFIG_DIR}}/flake"

--- a/flake.nix
+++ b/flake.nix
@@ -202,6 +202,7 @@
                               ''
                                 NIX_SSHOPTS="{{.REMOTE_SSH_OPTS}}" nix flake archive \
                                   --to ssh://{{.REMOTE_USER}}@{{.REMOTE_HOST}} \
+                                  --option builders-use-substitutes true \
                                   {{.LOCAL_FLAKE_SOURCE}}
                               ''
                               ''

--- a/module.nix
+++ b/module.nix
@@ -51,9 +51,9 @@ let
 in
 {
 
-  imports = [
-    (mkRemovedOptionModule ["lollypops" "deployment" "config-dir"] "The flake is now stored in the Nix store directly.")
-  ];
+  # imports = [
+  #   (mkRemovedOptionModule ["lollypops" "deployment" "config-dir"] "The flake is now stored in the Nix store directly.")
+  # ];
 
   options.lollypops = {
 
@@ -91,6 +91,12 @@ in
         type = types.bool;
         default = false;
         description = "Evaluate locally instead of on the remote when rebuilding";
+      };
+
+      config-dir = mkOption {
+        type = types.str;
+        default = "/var/src/lollypops";
+        description = "Path to place the configuration on the remote host";
       };
 
       group = mkOption {

--- a/module.nix
+++ b/module.nix
@@ -51,6 +51,10 @@ let
 in
 {
 
+  imports = [
+    (mkRemovedOptionModule ["lollypops" "deployment" "config-dir"] "The flake is now stored in the Nix store directly.")
+  ];
+
   options.lollypops = {
 
     secrets = {
@@ -87,12 +91,6 @@ in
         type = types.bool;
         default = false;
         description = "Evaluate locally instead of on the remote when rebuilding";
-      };
-
-      config-dir = mkOption {
-        type = types.str;
-        default = "/var/src/lollypops";
-        description = "Path to place the configuration on the remote host";
       };
 
       group = mkOption {

--- a/module.nix
+++ b/module.nix
@@ -190,8 +190,4 @@ in
 
     };
   };
-
-  config = {
-    environment.systemPackages = with pkgs; [ rsync ];
-  };
 }

--- a/module.nix
+++ b/module.nix
@@ -93,6 +93,21 @@ in
         description = "Evaluate locally instead of on the remote when rebuilding";
       };
 
+      deploy-method = mkOption {
+        type = types.enum [ "copy" "archive" ];
+        default = "copy";
+        description = ''
+          Method for copying flake to the remote. Using the default (`copy`) will
+          only deploy the flake itself, while `archive` deploys the flake and
+          all it's inputs to the remote machine. This is slower when deploying
+          from a connection with slow upload speed, but allows using inputs
+          which are not accessible from the remote.
+
+          When using `copy` all inputs of the flake will be substituted or
+          pulled from configured caches.
+        '';
+      };
+
       config-dir = mkOption {
         type = types.str;
         default = "/var/src/lollypops";


### PR DESCRIPTION
Fixes #30 
Replaces #33 

This get's rid of the rsync copy mechanism and dependency and replaces it by nix internal tooling. The a new option is introduced to select between `nix flake archive` and `nix copy` as copying meachnisms as both have pros and cons

TODO: document further.