### PR TITLE
Allow using current-running username for SSH connection

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -95,7 +95,8 @@
                       ];
 
                       vars = with hostConfig.config.lollypops; {
-                        REMOTE_USER = ''{{default "${deployment.ssh.user}" .LP_REMOTE_USER}}'';
+                        REMOTE_USER = if deployment.ssh.user == null then ''{{.USER}}''
+                                      else ''{{default "${deployment.ssh.user}" .LP_REMOTE_USER}}'';
                         REMOTE_HOST = ''{{default "${deployment.ssh.host}" .LP_REMOTE_HOST}}'';
                         REMOTE_COMMAND = ''{{default "${deployment.ssh.command}" .LP_REMOTE_COMMAND}}'';
                         REMOTE_SSH_OPTS = ''{{default "${pkgs.lib.concatStrings deployment.ssh.opts}" .LP_REMOTE_SSH_OPTS}}'';

--- a/module.nix
+++ b/module.nix
@@ -160,9 +160,15 @@ in
         };
 
         user = mkOption {
-          type = types.str;
+          type = types.nullOr types.str;
           default = "root";
-          description = "User to deploy as";
+          description = ''
+            User to deploy as.
+
+            If set to <literal>null</literal>, uses the name of the user that
+            invoked <literal>lollypops</literal>, as set by the
+            <literal>USER</literal> environment variable.
+          '';
         };
       };
     };


### PR DESCRIPTION
Hi!

tl;dr adds the possibility to set `ssh.user = null`, which when uses the `$USER` enviroment variable the username to connect as.
This is e.g. very useful for infrastructure that multiple people should be able to deploy, using their own, local username. 

`$USER` is normally for all user session on any *nix system, set by the login shell/ssh/sudo/etc.