### PR TITLE
feat(secrets): split vault name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # lollypops
 
 <p align="center">
-  <img src="https://user-images.githubusercontent.com/1719781/176185996-f7bd3919-df7f-4684-b464-46b414b46483.png" height="200"/>  
+  <img src="https://user-images.githubusercontent.com/1719781/176185996-f7bd3919-df7f-4684-b464-46b414b46483.png" height="200"/>
 </p>
 <p align="center">
   Lollypop Operations - NixOS Deployment Tool
@@ -247,7 +247,7 @@ to access the Nix daemon. This is the default in NixOS.
 ### Secrets
 
 Secrets are specified as attribute set under `lollypops.secrets.files`. All
-parameters are optional and can be omitted except the name. In it's default
+parameters are optional and can be omitted. In it's default
 configuration `pass` will be used to search for the secret placing it in
 `/run/keys/secretname` with permissions `0400` owned by `root:root`.
 
@@ -342,7 +342,7 @@ lollypops.extraTasks = {
 };
 ```
 
-In this example, the user has outlined that the `deploy-secrets`, `example` and `rebuild` tasks should run for this host.  
+In this example, the user has outlined that the `deploy-secrets`, `example` and `rebuild` tasks should run for this host.
 They have set the `rebuild` task to only run after the `example` task has finished successfully by using the `deps` keyword.
 Since `rebuild` is the name of one of the default tasks set to run (`deploy-secrets`, `deploy-flake` & `rebuild`) they are
 opting to override the default definition and instead define how they'd like to run a "rebuild" - in this case, they are
@@ -355,7 +355,7 @@ is omitted from the `lollypops.tasks` list.
 ### Debugging
 
 lollypops hides the executed commands in the default output. To enable full
-logging use the `--verbose` flag which is passed to go-task. 
+logging use the `--verbose` flag which is passed to go-task.
 
 ### Contributing
 

--- a/module.nix
+++ b/module.nix
@@ -15,11 +15,18 @@ let
         defaultText = "<name>";
       };
 
+      vault-name = mkOption {
+        type = types.str;
+        default = lib.concatStrings [cfg.secrets.cmd-name-prefix config.name];
+        description = "Name of the secret in the vault";
+        defaultText = "<cmd-name-prefix><name>";
+      };
+
       cmd = mkOption {
         type = types.str;
-        default = "${cfg.secrets.default-cmd} ${cfg.secrets.cmd-name-prefix}${config.name}";
+        default = "${cfg.secrets.default-cmd} ${config.vault-name}";
         description = "Command to print the secret. E.g. `cat mysecretfile`";
-        defaultText = "<default-cmd> <cmd-name-prefix><name>";
+        defaultText = "<default-cmd> <vault-name>";
       };
 
       path = mkOption {


### PR DESCRIPTION
Imagine the secret is called "My top secret SSH key" in your vault.
However, the file must be named `id_rsa`.

Now it's more ergonomic to declare.

@moduon MT-10454
