### PR TITLE
fix: add module keys to avoid duplicate imports

### DIFF
--- a/hm-module.nix
+++ b/hm-module.nix
@@ -48,6 +48,7 @@ let
   });
 in
 {
+  key = "github:pinpox/lollypops#hmModule";
 
   options.lollypops = {
 

--- a/module.nix
+++ b/module.nix
@@ -50,6 +50,7 @@ let
   });
 in
 {
+  key = "github:pinpox/lollypops#nixosModules.default";
 
   options.lollypops = {
 


### PR DESCRIPTION
If the module is imported more than once, it was giving an error such
as:

    error: The option `lollypops.extraTasks' in `/nix/store/...' is
    already declared in `/nix/store/...'.

By giving the modules a key, Nix is smart enough to avoid re-importing
them.

@moduon MT-10454
