### PR TITLE
fix: mkdir before linking flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -217,6 +217,10 @@
                               )
                               ''
                                 {{.REMOTE_COMMAND}} {{.REMOTE_SSH_OPTS}} {{.REMOTE_USER}}@{{.REMOTE_HOST}} \
+                                  "${optionalString useSudo "{{.REMOTE_SUDO_COMMAND}} {{.REMOTE_SUDO_OPTS}}"} mkdir -p {{.REMOTE_CONFIG_DIR}}"
+                              ''
+                              ''
+                                {{.REMOTE_COMMAND}} {{.REMOTE_SSH_OPTS}} {{.REMOTE_USER}}@{{.REMOTE_HOST}} \
                                   "${optionalString useSudo "{{.REMOTE_SUDO_COMMAND}} {{.REMOTE_SUDO_OPTS}}"} ln -sfn {{.LOCAL_FLAKE_SOURCE}} {{.REMOTE_CONFIG_DIR}}/flake"
                               ''
                             ];


### PR DESCRIPTION
Otherwise it will fail with `No such file or directory`.

@moduon MT-10454
