### PR TITLE
Fix issue where home-manager secrets were not deployed

### DIFF
--- a/packages/taskfile.nix
+++ b/packages/taskfile.nix
@@ -127,17 +127,9 @@ let
                   ]
                   ++ mkSeclist hostConfig.config
                   ++ (
-                    # Check for home-manager
-                    if builtins.hasAttr "home-manager" hostConfig.config then
-                      (
-                        # Check for lollypops homeModules.default
-                        if builtins.hasAttr "lollypops" hostConfig.config.home-manager then
-                          mkSeclistUser hostConfig.config.home-manager.users
-                        else
-                          [ ]
-                      )
-                    else
-                      [ ]
+                    lib.optionals
+                    (hostConfig.config ? "home-manager" && builtins.any (user: user ? "lollypops")
+                    (builtins.attrValues hostConfig.config.home-manager.users)) (mkSeclistUser hostConfig.config.home-manager.users)
                   );
               };
 


### PR DESCRIPTION
Hey, thanks for making this! I'm currently trying it out on my systems but I think I ran into an issue when using secrets for home-manager. `task` would just silently not deploy any secrets because the condition for deploying secrets checks if there is a `home-manager.lollypops`, when in reality it's any one of the _users_ that might have that attribute (i.e `home-manager.users.*.lollypops`). Luckily this is a simple enough fix.